### PR TITLE
Add rsession-ld-library-path

### DIFF
--- a/repo2docker/buildpacks/conda/__init__.py
+++ b/repo2docker/buildpacks/conda/__init__.py
@@ -312,6 +312,7 @@ class CondaBuildPack(BaseImage):
                     echo auth-none=1 >> /etc/rstudio/rserver.conf && \
                     echo auth-minimum-user-id=0 >> /etc/rstudio/rserver.conf && \
                     echo "rsession-which-r={0}/bin/R" >> /etc/rstudio/rserver.conf && \
+                    echo "rsession-ld-library-path={0}/lib" >> /etc/rstudio/rserver.conf && \
                     echo www-frame-origin=same >> /etc/rstudio/rserver.conf
                     """.format(
                         env_prefix


### PR DESCRIPTION
Fix https://discourse.jupyter.org/t/glibcxx-3-4-26-not-found-from-rstudio/7778/6

Ticket: GRDM-24512