### PR TITLE
[GRDM-28275, GRDM-30030] WEKO3ヘッダ解釈修正・JupyterLab拡張のキャッシュ削除

### DIFF
--- a/repo2docker/buildpacks/base.py
+++ b/repo2docker/buildpacks/base.py
@@ -106,6 +106,10 @@ COPY --chown={{ user }}:{{ user }} {{ src }} {{ dst }}
 {{ sd }}
 {% endfor %}
 
+{% if custom_extension_script is not none -%}
+RUN bash -c "{{ custom_extension_script }}"
+{% endif -%}
+
 # Allow target path repo is cloned to be configurable
 ARG REPO_DIR=${HOME}
 ENV REPO_DIR ${REPO_DIR}
@@ -162,10 +166,6 @@ LABEL {{k}}="{{v}}"
 
 # We always want containers to run as non-root
 USER ${NB_USER}
-
-{% if custom_extension_script is not none -%}
-RUN bash -c "{{ custom_extension_script }}"
-{% endif -%}
 
 {% if post_build_scripts -%}
 # Make sure that postBuild scripts are marked executable before executing them

--- a/repo2docker/buildpacks/conda/__init__.py
+++ b/repo2docker/buildpacks/conda/__init__.py
@@ -400,8 +400,10 @@ pip3 install {grdm_jlab_release_url}/rdm_binderhub_jlabextension-refs.tags.{grdm
 jupyter labextension install {grdm_jlab_release_url}/rdm-binderhub-jlabextension-refs.tags.{grdm_jlab_release_tag}.tgz
 jupyter labextension enable rdm-binderhub-jlabextension
 jupyter server extension enable rdm_binderhub_jlabextension
-jupyter nbextension install --py rdm_binderhub_jlabextension --user
-jupyter nbextension enable --py rdm_binderhub_jlabextension --user
+jupyter nbextension install --py rdm_binderhub_jlabextension
+jupyter nbextension enable --py rdm_binderhub_jlabextension
+jlpm cache clean
+npm cache clean --force
 """
         jlab_ext_script = " && ".join(
             [

--- a/repo2docker/contentproviders/rdm.py
+++ b/repo2docker/contentproviders/rdm.py
@@ -55,7 +55,7 @@ class RDM(ContentProvider):
                 else:
                     self.project_id = path
                     self.path = ""
-                self.uuid = ref if ref is not None else str(uuid.uuid1())
+                self.uuid = ref if self._check_ref_defined(ref) else str(uuid.uuid1())
                 return {
                     "project_id": self.project_id,
                     "path": self.path,
@@ -63,6 +63,11 @@ class RDM(ContentProvider):
                     "uuid": self.uuid,
                 }
         return None
+
+    def _check_ref_defined(self, ref):
+        if ref is None or ref == "HEAD":
+            return False
+        return True
 
     def fetch(self, spec, output_dir, yield_output=False):
         """Fetch RDM directory"""

--- a/repo2docker/contentproviders/weko3.py
+++ b/repo2docker/contentproviders/weko3.py
@@ -49,7 +49,7 @@ class WEKO3(ContentProvider):
         for host in self.hosts:
             if any([source.startswith(s) for s in host["hostname"]]):
                 self.url = source
-                self.uuid = ref if ref is not None else str(uuid.uuid1())
+                self.uuid = ref if self._check_ref_defined(ref) else str(uuid.uuid1())
                 return {
                     "url": self.url,
                     "host": host,
@@ -64,6 +64,11 @@ class WEKO3(ContentProvider):
 
         for msg in self._fetch_url(url, output_dir):
             yield msg
+
+    def _check_ref_defined(self, ref):
+        if ref is None or ref == "HEAD":
+            return False
+        return True
 
     def _log_403_error(self, url):
         self.log.error(f"403 Error: {url}")

--- a/tests/unit/contentproviders/test_rdm.py
+++ b/tests/unit/contentproviders/test_rdm.py
@@ -46,6 +46,15 @@ def test_detect_rdm_url():
     assert spec["uuid"] == "X1234"
     assert spec["host"]["api"] == "https://api.test.some.host.nii.ac.jp/v2/"
 
+    rdm = RDM()
+    spec = rdm.detect("https://test.some.host.nii.ac.jp/x1234/files/test", "HEAD")
+
+    assert spec is not None, spec
+    assert spec["project_id"] == "x1234"
+    assert spec["path"] == "test"
+    assert re.match(r"^[0-9A-Fa-f\-]+$", spec["uuid"]) is not None
+    assert spec["host"]["api"] == "https://api.test.some.host.nii.ac.jp/v2/"
+
 
 def test_not_detect_rdm_url():
     rdm = RDM()

--- a/tests/unit/contentproviders/test_weko3.py
+++ b/tests/unit/contentproviders/test_weko3.py
@@ -17,6 +17,26 @@ def test_detect_weko3_url():
     assert re.match(r"^[0-9A-Fa-f\-]+$", spec["uuid"]) is not None
     assert spec["host"]["hostname"] == ["https://test.some.host.nii.ac.jp/"]
 
+    weko3 = WEKO3()
+    spec = weko3.detect(
+        "https://test.some.host.nii.ac.jp/abcdefgh-12345678/test1.txt", ref="MYVERSION"
+    )
+
+    assert spec is not None, spec
+    assert spec["url"] == "https://test.some.host.nii.ac.jp/abcdefgh-12345678/test1.txt"
+    assert spec["uuid"] == "MYVERSION"
+    assert spec["host"]["hostname"] == ["https://test.some.host.nii.ac.jp/"]
+
+    weko3 = WEKO3()
+    spec = weko3.detect(
+        "https://test.some.host.nii.ac.jp/abcdefgh-12345678/test1.txt", ref="HEAD"
+    )
+
+    assert spec is not None, spec
+    assert spec["url"] == "https://test.some.host.nii.ac.jp/abcdefgh-12345678/test1.txt"
+    assert re.match(r"^[0-9A-Fa-f\-]+$", spec["uuid"]) is not None
+    assert spec["host"]["hostname"] == ["https://test.some.host.nii.ac.jp/"]
+
 
 def test_not_detect_weko3_url():
     weko3 = WEKO3()


### PR DESCRIPTION
以下の修正を実施しました。

* WEKO3ヘッダ解釈修正 - Content-Dispositionヘッダのext value対応/HEADブランチのタグ処理対応
* JupyterLab拡張のキャッシュ削除・インストール順序見直し