### PR TITLE
Fix order of script execution

### DIFF
--- a/repo2docker/buildpacks/base.py
+++ b/repo2docker/buildpacks/base.py
@@ -106,10 +106,6 @@ COPY --chown={{ user }}:{{ user }} {{ src }} {{ dst }}
 {{ sd }}
 {% endfor %}
 
-{% if custom_extension_script is not none -%}
-RUN bash -c "{{ custom_extension_script }}"
-{% endif -%}
-
 # Allow target path repo is cloned to be configurable
 ARG REPO_DIR=${HOME}
 ENV REPO_DIR ${REPO_DIR}
@@ -166,6 +162,10 @@ LABEL {{k}}="{{v}}"
 
 # We always want containers to run as non-root
 USER ${NB_USER}
+
+{% if custom_extension_script is not none -%}
+RUN bash -c "{{ custom_extension_script }}"
+{% endif -%}
 
 {% if post_build_scripts -%}
 # Make sure that postBuild scripts are marked executable before executing them


### PR DESCRIPTION
jupyterlab extensionがrootでインストールされてしまうケースを確認しましたので、順序変更commitをrevertさせてください。