### PR TITLE
解析環境のディスク利用量枯渇に関する問題への対応

### DIFF
--- a/repo2docker/buildpacks/conda/__init__.py
+++ b/repo2docker/buildpacks/conda/__init__.py
@@ -445,13 +445,20 @@ class CondaBuildPack(BaseImage):
             "https://github.com/RCOSDP/CS-jupyterlab-grdm/releases/download/0.1.0"
         )
         grdm_jlab_release_tag = "0.1.0"
+        jupyter_resource_usage_release_url = "https://github.com/RCOSDP/CS-jupyter-resource-usage"
+        jupyter_resource_usage_tag = "main"
         jlab_ext_scripts = f"""
-pip3 install {grdm_jlab_release_url}/rdm_binderhub_jlabextension-refs.tags.{grdm_jlab_release_tag}.tar.gz
+pip3 install {grdm_jlab_release_url}/rdm_binderhub_jlabextension-refs.tags.{grdm_jlab_release_tag}.tar.gz 
+pip3 install git+{jupyter_resource_usage_release_url}@{jupyter_resource_usage_tag}
 jupyter labextension install {grdm_jlab_release_url}/rdm-binderhub-jlabextension-refs.tags.{grdm_jlab_release_tag}.tgz
 jupyter labextension enable rdm-binderhub-jlabextension
 jupyter server extension enable rdm_binderhub_jlabextension
 jupyter nbextension install --py rdm_binderhub_jlabextension --user
 jupyter nbextension enable --py rdm_binderhub_jlabextension --user
+jupyter labextension enable jupyter_resource_usage
+jupyter serverextension enable --py jupyter_resource_usage
+jupyter nbextension install --py jupyter_resource_usage --user
+jupyter nbextension enable --py jupyter_resource_usage --user
 jlpm cache clean
 npm cache clean --force
 pip3 cache purge

--- a/repo2docker/buildpacks/repo2docker-entrypoint
+++ b/repo2docker/buildpacks/repo2docker-entrypoint
@@ -77,8 +77,11 @@ def main():
     def tee(chunk):
         """Tee output from child to both our stdout and the log file"""
         for f in [sys.stdout.buffer, log_file]:
-            f.write(chunk)
-            f.flush()
+            try:
+                f.write(chunk)
+                f.flush()
+            except OSError:
+                pass
 
     # make stdout pipe non-blocking
     # this means child.stdout.read(nbytes)


### PR DESCRIPTION
解析基盤から起動された環境上で、一度ディスクが枯渇してしまうとユーザが対処できなくなる件への対応として、以下の変更を行いました。
* repo2docker-entrypoint内で、起動時のログをファイルに書き込む場合に例外が発生した場合でも、そのまま起動を続行するように変更（このログは、podの標準出力ログにはそのまま残る）
* CondaBuildPack中の、Jupyter用のGakunin RDM拡張をインストール＆有効化している箇所で、jupyter_resource_usageも同時にインストールするよう変更
  * これにより、ユーザ自身が現在のディスク使用量を確認できるようになる