### PR TITLE
Send 'Accept: */*' header from WEKO3 ContentProvider

### DIFF
--- a/repo2docker/contentproviders/weko3.py
+++ b/repo2docker/contentproviders/weko3.py
@@ -148,6 +148,7 @@ class WEKO3(ContentProvider):
     def urlopen(self, req, headers=None):
         """A urlopen() helper"""
         req.add_header("User-Agent", "repo2docker {}".format(__version__))
+        req.add_header("Accept", "*/*")
         if headers is not None:
             for key, value in headers.items():
                 req.add_header(key, value)


### PR DESCRIPTION
WEKO3 ContentProviderでURLをフェッチする際に、WAFに弾かれてしまう現象を回避するため、Acceptヘッダを送信するよう変更しました。

https://redmine.devops.rcos.nii.ac.jp/issues/39029
