### PR TITLE
[GRDM-44637] CRANリポジトリの変更

### DIFF
--- a/repo2docker/buildpacks/conda/__init__.py
+++ b/repo2docker/buildpacks/conda/__init__.py
@@ -483,13 +483,14 @@ class CondaBuildPack(BaseImage):
         installR_path = self.binder_path("install.R")
         if not os.path.exists(installR_path):
             return []
-        repo_url = 'https://cran.ism.ac.jp/'
+        repo_url = 'https://cloud.r-project.org/'
         return [
             (
                 "${NB_USER}",
                 # Delete any downloaded packages in /tmp, as they aren't reused by R
                 f"""echo 'r = getOption("repos")' > /tmp/install.R && \
                 echo 'r["CRAN"] = "{repo_url}"' >> /tmp/install.R && \
+                echo 'options(warn = 2)' >> /tmp/install.R && \
                 echo 'options(repos = r)' >> /tmp/install.R && \
                 cat {installR_path} >> /tmp/install.R && \
                 Rscript /tmp/install.R && rm -rf /tmp/downloaded_packages""",

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ setup(
         "requests",
         "ruamel.yaml>=0.15",
         "semver",
-        "osfclient @ git+https://github.com/RCOSDP/rdmclient.git",
+        "osfclient @ git+https://github.com/RCOSDP/rdmclient.git@ab531e89148c4af48e4e1f123edc8e35690f31bc",
         "toml",
         "traitlets",
         "beautifulsoup4>=4.10.0",


### PR DESCRIPTION
現行のCRANリポジトリ設定がエラーになる場合が多いようでしたので、CRANリポジトリを cloud.r-project.org に変更し、エラーの際に適切に失敗するよう、install.Rの生成ロジックを修正しました。