### PR TITLE
[GRDM-58288] Replace `chardet` with `charset-normalizer`

### DIFF
--- a/repo2docker/utils.py
+++ b/repo2docker/utils.py
@@ -8,7 +8,7 @@ from enum import Enum
 from functools import partial
 from shutil import copy2, copystat
 
-import chardet
+import charset_normalizer
 from traitlets import Integer, TraitError
 
 
@@ -94,21 +94,13 @@ def chdir(path):
 def open_guess_encoding(path):
     """
     Open a file in text mode, specifying its encoding,
-    that we guess using chardet.
+    that we guess using charset_normalizer.
     """
-    detector = chardet.universaldetector.UniversalDetector()
     with open(path, "rb") as f:
-        for line in f.readlines():
-            detector.feed(line)
-            if detector.done:
-                break
-    detector.close()
+        detector = charset_normalizer.from_fp(f)
 
-    file = open(path, encoding=detector.result["encoding"])
-    try:
+    with open(path, encoding=detector.best().encoding) as file:
         yield file
-    finally:
-        file.close()
 
 
 def validate_and_generate_port_mapping(port_mappings):

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(
     name="jupyter-repo2docker",
     version=versioneer.get_version(),
     install_requires=[
-        "chardet",
+        "charset-normalizer",
         "docker!=5.0.0",
         "entrypoints",
         "escapism",


### PR DESCRIPTION
`chardet`はバージョン7でAPIの破壊的変更があるので、`chardet`の代わりに`charset-normalizer`を使うように変更するPRです。upstreamで同様の変更が[PR#1510](https://github.com/jupyterhub/repo2docker/pull/1510)として取り入れられており、このPRはプロジェクト設定ファイルの違い (upstream: `pyproject.toml` 、本フォーク: `setup.py`)以外はupstreamに取り入れられたのと同じ内容です。