### PR TITLE
[GRDM-59575] RStudioを含む基本イメージからの解析環境の起動失敗を修正

### DIFF
--- a/repo2docker/buildpacks/conda/__init__.py
+++ b/repo2docker/buildpacks/conda/__init__.py
@@ -595,8 +595,9 @@ rm -fr ~/.yarn/berry/cache
         )
 
         if post:
-            install_grdm = 'if(\\"devtools\\" %in% rownames(installed.packages())) ' \
-                + 'devtools::install_github(\\"RCOSDP/CS-rstudio-grdm\\", type = \\"source\\")'
+            install_grdm = 'options(repos = c(CRAN = \\"https://cloud.r-project.org/\\")); ' \
+                + 'if (!(\\"remotes\\" %in% rownames(installed.packages()))) install.packages(\\"remotes\\"); ' \
+                + 'remotes::install_github(\\"RCOSDP/CS-rstudio-grdm\\", type = \\"source\\")'
             bash_scripts = f"""
 if [ -x \\"$(command -v R)\\" ]; then R -e '{install_grdm}'; fi
 """


### PR DESCRIPTION
RStudioを含む基本イメージからの解析環境の起動に失敗する件を修正するPRです。

`devtools`はバージョン2.5.0以降で`remotes`パッケージが同時にインストールされなくなり、`devtools::install_github`は`remotes`を利用しているので、 `remotes` を他の方法でインストールしておかない限り動作しなくなりました。
conda用BuildPackでは `CS-rstudio-grdm` のインストールに `devtools::install_github` を利用しており、このためRStudioを含む基本イメージを用いた解析環境の構築に失敗するようになっていました。

本PRでは`CS-rstudio-grdm`のインストールに`remotes::install_github`を利用するように修正することで問題を修正します。