### PR TITLE
[GRDM-60339] CIの健全化

### DIFF
--- a/repo2docker/buildpacks/conda/__init__.py
+++ b/repo2docker/buildpacks/conda/__init__.py
@@ -1,4 +1,5 @@
 """BuildPack for conda environments"""
+
 import os
 import re
 import warnings
@@ -13,10 +14,10 @@ from ...utils import is_local_pip_requirement
 from .._r_base import rstudio_base_scripts
 from ..base import BaseImage
 from .matlab import (
-    matlab_requirements_scripts,
     matlab_installation_scripts,
-    matlab_python_engine_installation_scripts,
     matlab_proxy_installation_scripts,
+    matlab_python_engine_installation_scripts,
+    matlab_requirements_scripts,
 )
 
 # pattern for parsing conda dependency line
@@ -483,7 +484,7 @@ class CondaBuildPack(BaseImage):
         installR_path = self.binder_path("install.R")
         if not os.path.exists(installR_path):
             return []
-        repo_url = 'https://cloud.r-project.org/'
+        repo_url = "https://cloud.r-project.org/"
         return [
             (
                 "${NB_USER}",
@@ -512,8 +513,12 @@ class CondaBuildPack(BaseImage):
             raise ValueError("mpm.yml must contain a 'release' field")
         scripts = matlab_requirements_scripts(config["release"], self.base_image)
         matlab_dir = "/opt/matlab"
-        scripts += matlab_installation_scripts(config["release"], config.get("products", []), matlab_dir)
-        scripts += matlab_python_engine_installation_scripts(config["release"], matlab_dir)
+        scripts += matlab_installation_scripts(
+            config["release"], config.get("products", []), matlab_dir
+        )
+        scripts += matlab_python_engine_installation_scripts(
+            config["release"], matlab_dir
+        )
         scripts += matlab_proxy_installation_scripts()
         return scripts
 
@@ -524,18 +529,23 @@ class CondaBuildPack(BaseImage):
         return [("MW_CONTEXT_TAGS", "MATLAB_PROXY:JUPYTER:MPM:V1")]
 
     def _get_jlab_extension_script(
-        self, grdm_jlab_release_tag, grdm_jlab_filename_body, jupyter_resource_usage_tag,
+        self,
+        grdm_jlab_release_tag,
+        grdm_jlab_filename_body,
+        jupyter_resource_usage_tag,
         perform_labextension_install=True,
         perform_nbextension_install=True,
         perform_jlpm_cache_clean=True,
         perform_npm_cache_clean=True,
     ):
-        grdm_jlab_release_url = (
-            f"https://github.com/RCOSDP/CS-jupyterlab-grdm/releases/download/{grdm_jlab_release_tag}"
+        grdm_jlab_release_url = f"https://github.com/RCOSDP/CS-jupyterlab-grdm/releases/download/{grdm_jlab_release_tag}"
+        jupyter_resource_usage_release_url = (
+            "https://github.com/RCOSDP/CS-jupyter-resource-usage"
         )
-        jupyter_resource_usage_release_url = "https://github.com/RCOSDP/CS-jupyter-resource-usage"
         grdm_jlab_filename_tar_gz = f"{grdm_jlab_filename_body}.tar.gz"
-        grdm_jlab_filename_tgz = "{}.tgz".format(grdm_jlab_filename_body.replace("_", "-"))
+        grdm_jlab_filename_tgz = "{}.tgz".format(
+            grdm_jlab_filename_body.replace("_", "-")
+        )
         jlpm_cache_clean = ""
         if perform_jlpm_cache_clean:
             jlpm_cache_clean = "jlpm cache clean"
@@ -578,16 +588,24 @@ rm -fr ~/.yarn/berry/cache
 
     def get_custom_extension_script(self, post):
         grdm_jlab3_release_tag = "0.2.0"
-        grdm_jlab3_filename_body = f"rdm_binderhub_jlabextension-refs.tags.{grdm_jlab3_release_tag}"
+        grdm_jlab3_filename_body = (
+            f"rdm_binderhub_jlabextension-refs.tags.{grdm_jlab3_release_tag}"
+        )
 
         grdm_jlab4_release_tag = "0.3.0"
-        grdm_jlab4_filename_body = f"rdm_binderhub_jlabextension-{grdm_jlab4_release_tag}"
+        grdm_jlab4_filename_body = (
+            f"rdm_binderhub_jlabextension-{grdm_jlab4_release_tag}"
+        )
 
         jlab3_ext_script = self._get_jlab_extension_script(
-            grdm_jlab3_release_tag, grdm_jlab3_filename_body, 'v2023.07',
+            grdm_jlab3_release_tag,
+            grdm_jlab3_filename_body,
+            "v2023.07",
         )
         jlab4_ext_script = self._get_jlab_extension_script(
-            grdm_jlab4_release_tag, grdm_jlab4_filename_body, 'v2024.04',
+            grdm_jlab4_release_tag,
+            grdm_jlab4_filename_body,
+            "v2024.04",
             perform_labextension_install=False,
             perform_nbextension_install=False,
             perform_jlpm_cache_clean=False,
@@ -595,9 +613,14 @@ rm -fr ~/.yarn/berry/cache
         )
 
         if post:
-            install_grdm = 'options(repos = c(CRAN = \\"https://cloud.r-project.org/\\")); ' \
-                + 'if (!(\\"remotes\\" %in% rownames(installed.packages()))) install.packages(\\"remotes\\"); ' \
-                + 'remotes::install_github(\\"RCOSDP/CS-rstudio-grdm\\", type = \\"source\\")'
+            # install from the GitHub archive tarball; install_github queries
+            # api.github.com, which is rate-limited for unauthenticated builds
+            install_grdm = (
+                'options(repos = c(CRAN = \\"https://cloud.r-project.org/\\")); '
+                + 'if (!(\\"remotes\\" %in% rownames(installed.packages()))) install.packages(\\"remotes\\"); '
+                + 'remotes::install_url(\\"https://github.com/RCOSDP/CS-rstudio-grdm/archive/refs/heads/master.tar.gz\\"); '
+                + 'stopifnot(\\"rdmaddins\\" %in% rownames(installed.packages()))'
+            )
             bash_scripts = f"""
 if [ -x \\"$(command -v R)\\" ]; then R -e '{install_grdm}'; fi
 """

--- a/repo2docker/buildpacks/r.py
+++ b/repo2docker/buildpacks/r.py
@@ -417,7 +417,7 @@ class RBuildPack(PythonBuildPack):
             assemble_scripts += [
                 (
                     "${NB_USER}",
-                    'R --no-save --no-restore --no-init-file --no-environ --quiet -e "pak::local_install()"',
+                    'R --no-save --no-restore --no-init-file --no-environ --quiet -e "pak::local_install()" && rm -rf $HOME/.cache/R',
                 )
             ]
 

--- a/repo2docker/buildpacks/r.py
+++ b/repo2docker/buildpacks/r.py
@@ -350,10 +350,10 @@ class RBuildPack(PythonBuildPack):
             ),
             (
                 "${NB_USER}",
-                # Install a pinned version of devtools, IRKernel and shiny
+                # Install a pinned version of pak, devtools, IRKernel and shiny
                 rf"""
                 export EXPANDED_CRAN_MIRROR_URL="$(. /etc/os-release && echo {cran_mirror_url} | envsubst)" && \
-                R --no-save --no-restore --no-init-file --no-environ --quiet -e "install.packages(c('devtools', 'IRkernel', 'shiny'), repos=Sys.getenv(\"EXPANDED_CRAN_MIRROR_URL\"))" && \
+                R --no-save --no-restore --no-init-file --no-environ --quiet -e "install.packages(c('pak', 'devtools', 'IRkernel', 'shiny'), repos=Sys.getenv(\"EXPANDED_CRAN_MIRROR_URL\"))" && \
                 R --no-save --no-restore --no-init-file --no-environ --quiet -e "IRkernel::installspec(prefix=Sys.getenv(\"NB_PYTHON_PREFIX\"))"
                 """,
             ),
@@ -417,7 +417,10 @@ class RBuildPack(PythonBuildPack):
             assemble_scripts += [
                 (
                     "${NB_USER}",
-                    'R --no-save --no-restore --no-init-file --no-environ --quiet -e "pak::local_install()" && rm -rf $HOME/.cache/R',
+                    # pak doesn't seem to cleanup after itself.
+                    # pak::cache_clean() doesn't empty the cache,
+                    # it leaves files in /tmp/Rabc123.../ and ~/.cache/R/pkg/...
+                    'R --no-save --no-restore --no-init-file --no-environ --quiet -e "pak::install_local()"; rm -rf $HOME/.cache/R; rm -rf /tmp/R*',
                 )
             ]
 

--- a/repo2docker/buildpacks/r.py
+++ b/repo2docker/buildpacks/r.py
@@ -417,7 +417,7 @@ class RBuildPack(PythonBuildPack):
             assemble_scripts += [
                 (
                     "${NB_USER}",
-                    'R --no-save --no-restore --no-init-file --no-environ --quiet -e "devtools::install_local(getwd())"',
+                    'R --no-save --no-restore --no-init-file --no-environ --quiet -e "pak::local_install()"',
                 )
             ]
 

--- a/repo2docker/buildpacks/r.py
+++ b/repo2docker/buildpacks/r.py
@@ -350,10 +350,10 @@ class RBuildPack(PythonBuildPack):
             ),
             (
                 "${NB_USER}",
-                # Install a pinned version of pak, devtools, IRKernel and shiny
+                # Install a pinned version of remotes, devtools, IRKernel and shiny
                 rf"""
                 export EXPANDED_CRAN_MIRROR_URL="$(. /etc/os-release && echo {cran_mirror_url} | envsubst)" && \
-                R --no-save --no-restore --no-init-file --no-environ --quiet -e "install.packages(c('pak', 'devtools', 'IRkernel', 'shiny'), repos=Sys.getenv(\"EXPANDED_CRAN_MIRROR_URL\"))" && \
+                R --no-save --no-restore --no-init-file --no-environ --quiet -e "install.packages(c('remotes', 'devtools', 'IRkernel', 'shiny'), repos=Sys.getenv(\"EXPANDED_CRAN_MIRROR_URL\"))" && \
                 R --no-save --no-restore --no-init-file --no-environ --quiet -e "IRkernel::installspec(prefix=Sys.getenv(\"NB_PYTHON_PREFIX\"))"
                 """,
             ),
@@ -417,10 +417,7 @@ class RBuildPack(PythonBuildPack):
             assemble_scripts += [
                 (
                     "${NB_USER}",
-                    # pak doesn't seem to cleanup after itself.
-                    # pak::cache_clean() doesn't empty the cache,
-                    # it leaves files in /tmp/Rabc123.../ and ~/.cache/R/pkg/...
-                    'R --no-save --no-restore --no-init-file --no-environ --quiet -e "pak::install_local()"; rm -rf $HOME/.cache/R; rm -rf /tmp/R*',
+                    'R --no-save --no-restore --no-init-file --no-environ --quiet -e "remotes::install_local()"',
                 )
             ]
 

--- a/repo2docker/buildpacks/r.py
+++ b/repo2docker/buildpacks/r.py
@@ -353,8 +353,8 @@ class RBuildPack(PythonBuildPack):
                 # Install a pinned version of devtools, IRKernel and shiny
                 rf"""
                 export EXPANDED_CRAN_MIRROR_URL="$(. /etc/os-release && echo {cran_mirror_url} | envsubst)" && \
-                R --quiet -e "install.packages(c('devtools', 'IRkernel', 'shiny'), repos=Sys.getenv(\"EXPANDED_CRAN_MIRROR_URL\"))" && \
-                R --quiet -e "IRkernel::installspec(prefix=Sys.getenv(\"NB_PYTHON_PREFIX\"))"
+                R --vanilla --quiet -e "install.packages(c('devtools', 'IRkernel', 'shiny'), repos=Sys.getenv(\"EXPANDED_CRAN_MIRROR_URL\"))" && \
+                R --vanilla --quiet -e "IRkernel::installspec(prefix=Sys.getenv(\"NB_PYTHON_PREFIX\"))"
                 """,
             ),
         ]
@@ -390,7 +390,7 @@ class RBuildPack(PythonBuildPack):
                     "${NB_USER}",
                     # Delete /tmp/downloaded_packages only if install.R fails, as the second
                     # invocation of install.R might be able to reuse them
-                    f"Rscript {installR_path} && touch /tmp/.preassembled || true && rm -rf /tmp/downloaded_packages",
+                    f"Rscript --vanilla {installR_path} && touch /tmp/.preassembled || true && rm -rf /tmp/downloaded_packages",
                 )
             ]
 
@@ -408,14 +408,14 @@ class RBuildPack(PythonBuildPack):
                     "${NB_USER}",
                     # only run install.R if the pre-assembly failed
                     # Delete any downloaded packages in /tmp, as they aren't reused by R
-                    f"""if [ ! -f /tmp/.preassembled ]; then Rscript {installR_path}; rm -rf /tmp/downloaded_packages; fi""",
+                    f"""if [ ! -f /tmp/.preassembled ]; then Rscript --vanilla {installR_path}; rm -rf /tmp/downloaded_packages; fi""",
                 )
             ]
 
         description_R = "DESCRIPTION"
         if not self.binder_dir and os.path.exists(description_R):
             assemble_scripts += [
-                ("${NB_USER}", 'R --quiet -e "devtools::install_local(getwd())"')
+                ("${NB_USER}", 'R --vanilla --quiet -e "devtools::install_local(getwd())"')
             ]
 
         return assemble_scripts

--- a/repo2docker/buildpacks/r.py
+++ b/repo2docker/buildpacks/r.py
@@ -353,8 +353,8 @@ class RBuildPack(PythonBuildPack):
                 # Install a pinned version of devtools, IRKernel and shiny
                 rf"""
                 export EXPANDED_CRAN_MIRROR_URL="$(. /etc/os-release && echo {cran_mirror_url} | envsubst)" && \
-                R --vanilla --quiet -e "install.packages(c('devtools', 'IRkernel', 'shiny'), repos=Sys.getenv(\"EXPANDED_CRAN_MIRROR_URL\"))" && \
-                R --vanilla --quiet -e "IRkernel::installspec(prefix=Sys.getenv(\"NB_PYTHON_PREFIX\"))"
+                R --no-save --no-restore --no-init-file --no-environ --quiet -e "install.packages(c('devtools', 'IRkernel', 'shiny'), repos=Sys.getenv(\"EXPANDED_CRAN_MIRROR_URL\"))" && \
+                R --no-save --no-restore --no-init-file --no-environ --quiet -e "IRkernel::installspec(prefix=Sys.getenv(\"NB_PYTHON_PREFIX\"))"
                 """,
             ),
         ]
@@ -390,7 +390,7 @@ class RBuildPack(PythonBuildPack):
                     "${NB_USER}",
                     # Delete /tmp/downloaded_packages only if install.R fails, as the second
                     # invocation of install.R might be able to reuse them
-                    f"Rscript --vanilla {installR_path} && touch /tmp/.preassembled || true && rm -rf /tmp/downloaded_packages",
+                    f"Rscript --no-save --no-restore --no-init-file --no-environ {installR_path} && touch /tmp/.preassembled || true && rm -rf /tmp/downloaded_packages",
                 )
             ]
 
@@ -408,14 +408,17 @@ class RBuildPack(PythonBuildPack):
                     "${NB_USER}",
                     # only run install.R if the pre-assembly failed
                     # Delete any downloaded packages in /tmp, as they aren't reused by R
-                    f"""if [ ! -f /tmp/.preassembled ]; then Rscript --vanilla {installR_path}; rm -rf /tmp/downloaded_packages; fi""",
+                    f"""if [ ! -f /tmp/.preassembled ]; then Rscript --no-save --no-restore --no-init-file --no-environ {installR_path}; rm -rf /tmp/downloaded_packages; fi""",
                 )
             ]
 
         description_R = "DESCRIPTION"
         if not self.binder_dir and os.path.exists(description_R):
             assemble_scripts += [
-                ("${NB_USER}", 'R --vanilla --quiet -e "devtools::install_local(getwd())"')
+                (
+                    "${NB_USER}",
+                    'R --no-save --no-restore --no-init-file --no-environ --quiet -e "devtools::install_local(getwd())"',
+                )
             ]
 
         return assemble_scripts

--- a/repo2docker/contentproviders/figshare.py
+++ b/repo2docker/contentproviders/figshare.py
@@ -41,7 +41,9 @@ class Figshare(DoiProvider):
     # We may need to add other item types in future, see
     # https://github.com/jupyterhub/repo2docker/pull/1001#issuecomment-760107436
     # for a list
-    url_regex = re.compile(r"(.*)/articles/(code/|dataset/)?([^/]+)/(\d+)(/)?(\d+)?")
+    url_regex = re.compile(
+        r"(.*)/articles/(code/|dataset/|software/)?([^/]+)/(\d+)(/)?(\d+)?"
+    )
 
     def detect(self, doi, ref=None, extra_args=None):
         """Trigger this provider for things that resolve to a Figshare article"""

--- a/repo2docker/utils.py
+++ b/repo2docker/utils.py
@@ -8,7 +8,7 @@ from enum import Enum
 from functools import partial
 from shutil import copy2, copystat
 
-import chardet
+import charset_normalizer
 from traitlets import Integer, TraitError
 
 
@@ -94,21 +94,13 @@ def chdir(path):
 def open_guess_encoding(path):
     """
     Open a file in text mode, specifying its encoding,
-    that we guess using chardet.
+    that we guess using charset_normalizer.
     """
-    detector = chardet.UniversalDetector()
     with open(path, "rb") as f:
-        for line in f.readlines():
-            detector.feed(line)
-            if detector.done:
-                break
-    detector.close()
+        detector = charset_normalizer.from_fp(f)
 
-    file = open(path, encoding=detector.result["encoding"])
-    try:
+    with open(path, encoding=detector.best().encoding) as file:
         yield file
-    finally:
-        file.close()
 
 
 def validate_and_generate_port_mapping(port_mappings):

--- a/repo2docker/utils.py
+++ b/repo2docker/utils.py
@@ -96,7 +96,7 @@ def open_guess_encoding(path):
     Open a file in text mode, specifying its encoding,
     that we guess using chardet.
     """
-    detector = chardet.universaldetector.UniversalDetector()
+    detector = chardet.UniversalDetector()
     with open(path, "rb") as f:
         for line in f.readlines():
             detector.feed(line)

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(
     name="jupyter-repo2docker",
     version=versioneer.get_version(),
     install_requires=[
-        "chardet",
+        "charset-normalizer",
         "docker!=5.0.0",
         "entrypoints",
         "escapism",


### PR DESCRIPTION
CIを健全化するPRです。環境の経年変化に起因するテスト失敗を、upstream (jupyterhub/repo2docker) で解消済みの問題のcherry-pickおよびfork固有処理の修正により解消します。

## 1. chardet 6.x の非互換 (unit / venv / external の失敗)

2026年3月頃にリリースされた chardet 6.x で `chardet.universaldetector` という小文字モジュール経由のアクセスが廃止され、`utils.py` の `open_guess_encoding` が `AttributeError` で失敗するようになりました。

- jupyterhub/repo2docker@3f4296f6 `fix import of universaldetector`
- jupyterhub/repo2docker@847980b1 `actually, let's avoid chardet altogether` (chardet を charset-normalizer に置換)

後者は upstream では `pyproject.toml` の依存変更を含みますが、本forkは `setup.py` で依存を管理しているため、その部分のみ `setup.py` への変更として解決しています。なお、同趣旨のPRとして #24 がありましたが、upstreamコミットのcherry-pickで対応する方針としたため、本PRで置き換えます。

## 2. figshare のURL正規表現 (unit の失敗)

- jupyterhub/repo2docker@5edd0912 `fix figshare url regex`

## 3. DESCRIPTION型リポジトリのビルド失敗 (r の失敗)

DESCRIPTIONファイルを持つリポジトリのインストールは `devtools::install_local(getwd())` で行われていますが、devtoolsは依存パッケージが多く、デフォルトのR (4.2.1) と最新のCRANスナップショットの組み合わせではPositのバイナリ提供が終了しているためソースビルドに落ち、依存の `curl` パッケージ等のビルド失敗によりdevtools自体がインストールされず、ビルドが失敗します(`tests/r/r-rspm-description-file`)。

upstreamは `devtools::install_local` の廃止(deprecated)対応としてこの経路を依存ゼロの `remotes` ベースに変更済みのため、該当コミットをcherry-pickします。

- jupyterhub/repo2docker@bcb46e14 `Add --vanilla to R call`
- jupyterhub/repo2docker@673e1bda `Replace --vanilla with --no-init-file`
- jupyterhub/repo2docker@066b12c8 `R: install with pak`
- jupyterhub/repo2docker@09cadb55 `clear cache after pak install`
- jupyterhub/repo2docker@37e5fbdb `manually cleanup after pak`
- jupyterhub/repo2docker@6882be5d `remotes doesn't leave a mess` (pakをやめてremotesに変更した最終形)

途中でpakを経由しているのはupstreamの試行の経緯をそのまま保持しているためで、最終状態は「基本インストールに `remotes` を追加し、DESCRIPTIONのインストールを `remotes::install_local()` で行う」となります。upstreamのCIでは同一のテストfixtureがこの構成でpassしています。

## 4. CS-rstudio-grdm インストールの GitHub API 依存の除去 (r の失敗・fork固有)

`CS-rstudio-grdm` のインストールに使用している `remotes::install_github` は api.github.com を無認証で参照するため、レートリミットによりビルドが確率的に失敗します(CIランナーの共有IPでは高頻度)。API を参照しない GitHub アーカイブ tarball からの取得 (`remotes::install_url`) に変更し、あわせてインストール結果の検証 (`stopifnot`) を追加してインストール失敗が確実にビルドエラーとして顕在化するようにしました。これは #25 で `remotes::install_github` 化した処理の改善です。

## 動作確認

- ローカルで `tests/unit/test_utils.py` 37件、`tests/unit/contentproviders/test_figshare.py` 14件、`tests/unit/test_r.py` 9件のパスを確認済み
- `tests/r/r-rspm-description-file` に対する生成Dockerfileが upstream と同一のインストールコマンドになることを確認済み
- CS-rstudio-grdm の tarball インストールについては、ローカルDocker環境で remotes のブートストラップ→依存解決 (jsonlite)→`rdmaddins` のインストールまでを実行し、RStudio の Addins メニューに「Sync to RDM」が表示される(Addinが有効化される)ことをブラウザ上で確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)