### PR TITLE
[GRDM-XXXXX] DESCRIPTIONインストールをremotesベースに変更 (upstreamのcherry-pick)

### DIFF
--- a/repo2docker/buildpacks/r.py
+++ b/repo2docker/buildpacks/r.py
@@ -417,7 +417,7 @@ class RBuildPack(PythonBuildPack):
             assemble_scripts += [
                 (
                     "${NB_USER}",
-                    'R --no-save --no-restore --no-init-file --no-environ --quiet -e "pak::local_install()"',
+                    'R --no-save --no-restore --no-init-file --no-environ --quiet -e "pak::local_install()" && rm -rf $HOME/.cache/R',
                 )
             ]
 

--- a/repo2docker/buildpacks/r.py
+++ b/repo2docker/buildpacks/r.py
@@ -350,10 +350,10 @@ class RBuildPack(PythonBuildPack):
             ),
             (
                 "${NB_USER}",
-                # Install a pinned version of devtools, IRKernel and shiny
+                # Install a pinned version of pak, devtools, IRKernel and shiny
                 rf"""
                 export EXPANDED_CRAN_MIRROR_URL="$(. /etc/os-release && echo {cran_mirror_url} | envsubst)" && \
-                R --no-save --no-restore --no-init-file --no-environ --quiet -e "install.packages(c('devtools', 'IRkernel', 'shiny'), repos=Sys.getenv(\"EXPANDED_CRAN_MIRROR_URL\"))" && \
+                R --no-save --no-restore --no-init-file --no-environ --quiet -e "install.packages(c('pak', 'devtools', 'IRkernel', 'shiny'), repos=Sys.getenv(\"EXPANDED_CRAN_MIRROR_URL\"))" && \
                 R --no-save --no-restore --no-init-file --no-environ --quiet -e "IRkernel::installspec(prefix=Sys.getenv(\"NB_PYTHON_PREFIX\"))"
                 """,
             ),
@@ -417,7 +417,10 @@ class RBuildPack(PythonBuildPack):
             assemble_scripts += [
                 (
                     "${NB_USER}",
-                    'R --no-save --no-restore --no-init-file --no-environ --quiet -e "pak::local_install()" && rm -rf $HOME/.cache/R',
+                    # pak doesn't seem to cleanup after itself.
+                    # pak::cache_clean() doesn't empty the cache,
+                    # it leaves files in /tmp/Rabc123.../ and ~/.cache/R/pkg/...
+                    'R --no-save --no-restore --no-init-file --no-environ --quiet -e "pak::install_local()"; rm -rf $HOME/.cache/R; rm -rf /tmp/R*',
                 )
             ]
 

--- a/repo2docker/buildpacks/r.py
+++ b/repo2docker/buildpacks/r.py
@@ -417,7 +417,7 @@ class RBuildPack(PythonBuildPack):
             assemble_scripts += [
                 (
                     "${NB_USER}",
-                    'R --no-save --no-restore --no-init-file --no-environ --quiet -e "devtools::install_local(getwd())"',
+                    'R --no-save --no-restore --no-init-file --no-environ --quiet -e "pak::local_install()"',
                 )
             ]
 

--- a/repo2docker/buildpacks/r.py
+++ b/repo2docker/buildpacks/r.py
@@ -350,10 +350,10 @@ class RBuildPack(PythonBuildPack):
             ),
             (
                 "${NB_USER}",
-                # Install a pinned version of pak, devtools, IRKernel and shiny
+                # Install a pinned version of remotes, devtools, IRKernel and shiny
                 rf"""
                 export EXPANDED_CRAN_MIRROR_URL="$(. /etc/os-release && echo {cran_mirror_url} | envsubst)" && \
-                R --no-save --no-restore --no-init-file --no-environ --quiet -e "install.packages(c('pak', 'devtools', 'IRkernel', 'shiny'), repos=Sys.getenv(\"EXPANDED_CRAN_MIRROR_URL\"))" && \
+                R --no-save --no-restore --no-init-file --no-environ --quiet -e "install.packages(c('remotes', 'devtools', 'IRkernel', 'shiny'), repos=Sys.getenv(\"EXPANDED_CRAN_MIRROR_URL\"))" && \
                 R --no-save --no-restore --no-init-file --no-environ --quiet -e "IRkernel::installspec(prefix=Sys.getenv(\"NB_PYTHON_PREFIX\"))"
                 """,
             ),
@@ -417,10 +417,7 @@ class RBuildPack(PythonBuildPack):
             assemble_scripts += [
                 (
                     "${NB_USER}",
-                    # pak doesn't seem to cleanup after itself.
-                    # pak::cache_clean() doesn't empty the cache,
-                    # it leaves files in /tmp/Rabc123.../ and ~/.cache/R/pkg/...
-                    'R --no-save --no-restore --no-init-file --no-environ --quiet -e "pak::install_local()"; rm -rf $HOME/.cache/R; rm -rf /tmp/R*',
+                    'R --no-save --no-restore --no-init-file --no-environ --quiet -e "remotes::install_local()"',
                 )
             ]
 

--- a/repo2docker/buildpacks/r.py
+++ b/repo2docker/buildpacks/r.py
@@ -353,8 +353,8 @@ class RBuildPack(PythonBuildPack):
                 # Install a pinned version of devtools, IRKernel and shiny
                 rf"""
                 export EXPANDED_CRAN_MIRROR_URL="$(. /etc/os-release && echo {cran_mirror_url} | envsubst)" && \
-                R --quiet -e "install.packages(c('devtools', 'IRkernel', 'shiny'), repos=Sys.getenv(\"EXPANDED_CRAN_MIRROR_URL\"))" && \
-                R --quiet -e "IRkernel::installspec(prefix=Sys.getenv(\"NB_PYTHON_PREFIX\"))"
+                R --vanilla --quiet -e "install.packages(c('devtools', 'IRkernel', 'shiny'), repos=Sys.getenv(\"EXPANDED_CRAN_MIRROR_URL\"))" && \
+                R --vanilla --quiet -e "IRkernel::installspec(prefix=Sys.getenv(\"NB_PYTHON_PREFIX\"))"
                 """,
             ),
         ]
@@ -390,7 +390,7 @@ class RBuildPack(PythonBuildPack):
                     "${NB_USER}",
                     # Delete /tmp/downloaded_packages only if install.R fails, as the second
                     # invocation of install.R might be able to reuse them
-                    f"Rscript {installR_path} && touch /tmp/.preassembled || true && rm -rf /tmp/downloaded_packages",
+                    f"Rscript --vanilla {installR_path} && touch /tmp/.preassembled || true && rm -rf /tmp/downloaded_packages",
                 )
             ]
 
@@ -408,14 +408,14 @@ class RBuildPack(PythonBuildPack):
                     "${NB_USER}",
                     # only run install.R if the pre-assembly failed
                     # Delete any downloaded packages in /tmp, as they aren't reused by R
-                    f"""if [ ! -f /tmp/.preassembled ]; then Rscript {installR_path}; rm -rf /tmp/downloaded_packages; fi""",
+                    f"""if [ ! -f /tmp/.preassembled ]; then Rscript --vanilla {installR_path}; rm -rf /tmp/downloaded_packages; fi""",
                 )
             ]
 
         description_R = "DESCRIPTION"
         if not self.binder_dir and os.path.exists(description_R):
             assemble_scripts += [
-                ("${NB_USER}", 'R --quiet -e "devtools::install_local(getwd())"')
+                ("${NB_USER}", 'R --vanilla --quiet -e "devtools::install_local(getwd())"')
             ]
 
         return assemble_scripts

--- a/repo2docker/buildpacks/r.py
+++ b/repo2docker/buildpacks/r.py
@@ -353,8 +353,8 @@ class RBuildPack(PythonBuildPack):
                 # Install a pinned version of devtools, IRKernel and shiny
                 rf"""
                 export EXPANDED_CRAN_MIRROR_URL="$(. /etc/os-release && echo {cran_mirror_url} | envsubst)" && \
-                R --vanilla --quiet -e "install.packages(c('devtools', 'IRkernel', 'shiny'), repos=Sys.getenv(\"EXPANDED_CRAN_MIRROR_URL\"))" && \
-                R --vanilla --quiet -e "IRkernel::installspec(prefix=Sys.getenv(\"NB_PYTHON_PREFIX\"))"
+                R --no-save --no-restore --no-init-file --no-environ --quiet -e "install.packages(c('devtools', 'IRkernel', 'shiny'), repos=Sys.getenv(\"EXPANDED_CRAN_MIRROR_URL\"))" && \
+                R --no-save --no-restore --no-init-file --no-environ --quiet -e "IRkernel::installspec(prefix=Sys.getenv(\"NB_PYTHON_PREFIX\"))"
                 """,
             ),
         ]
@@ -390,7 +390,7 @@ class RBuildPack(PythonBuildPack):
                     "${NB_USER}",
                     # Delete /tmp/downloaded_packages only if install.R fails, as the second
                     # invocation of install.R might be able to reuse them
-                    f"Rscript --vanilla {installR_path} && touch /tmp/.preassembled || true && rm -rf /tmp/downloaded_packages",
+                    f"Rscript --no-save --no-restore --no-init-file --no-environ {installR_path} && touch /tmp/.preassembled || true && rm -rf /tmp/downloaded_packages",
                 )
             ]
 
@@ -408,14 +408,17 @@ class RBuildPack(PythonBuildPack):
                     "${NB_USER}",
                     # only run install.R if the pre-assembly failed
                     # Delete any downloaded packages in /tmp, as they aren't reused by R
-                    f"""if [ ! -f /tmp/.preassembled ]; then Rscript --vanilla {installR_path}; rm -rf /tmp/downloaded_packages; fi""",
+                    f"""if [ ! -f /tmp/.preassembled ]; then Rscript --no-save --no-restore --no-init-file --no-environ {installR_path}; rm -rf /tmp/downloaded_packages; fi""",
                 )
             ]
 
         description_R = "DESCRIPTION"
         if not self.binder_dir and os.path.exists(description_R):
             assemble_scripts += [
-                ("${NB_USER}", 'R --vanilla --quiet -e "devtools::install_local(getwd())"')
+                (
+                    "${NB_USER}",
+                    'R --no-save --no-restore --no-init-file --no-environ --quiet -e "devtools::install_local(getwd())"',
+                )
             ]
 
         return assemble_scripts


### PR DESCRIPTION
DESCRIPTION型リポジトリのビルド失敗を修正するPRです。

DESCRIPTIONファイルを持つリポジトリのインストールは `devtools::install_local(getwd())` で行われていますが、devtoolsは依存パッケージが多く、デフォルトのR (4.2.1) と最新のCRANスナップショットの組み合わせではPositのバイナリ提供が終了しているためソースビルドに落ち、依存の `curl` パッケージ等のビルド失敗によりdevtools自体がインストールされず、ビルドが失敗するようになっています(CIの `tests/r/r-rspm-description-file` が失敗。masterでも同様です)。

upstream (jupyterhub/repo2docker) では、`devtools::install_local` の廃止(deprecated)対応としてこの経路を依存ゼロの `remotes` ベースに変更済みのため、該当コミットをcherry-pickします。

- jupyterhub/repo2docker@bcb46e14 `Add --vanilla to R call`
- jupyterhub/repo2docker@673e1bda `Replace --vanilla with --no-init-file`
- jupyterhub/repo2docker@066b12c8 `R: install with pak`
- jupyterhub/repo2docker@09cadb55 `clear cache after pak install`
- jupyterhub/repo2docker@37e5fbdb `manually cleanup after pak`
- jupyterhub/repo2docker@6882be5d `remotes doesn't leave a mess` (pakをやめてremotesに変更した最終形)

途中でpakを経由しているのはupstreamの試行の経緯をそのまま保持しているためで、最終状態は「基本インストールに `remotes` を追加し、DESCRIPTIONのインストールを `remotes::install_local()` で行う」となります。remotesは依存パッケージを持たない純Rパッケージのため、バイナリ提供状況の影響を受けません。upstreamのCIでは同一のテストfixtureがこの構成でpassしています。

conflictの解決は1箇所のみです(`673e1bda` のRコマンドラインの文脈差)。

動作確認: `tests/unit/test_r.py` 9件のパス、および `tests/r/r-rspm-description-file` に対する生成Dockerfileが upstream と同一のインストールコマンドになることを確認済みです。CIでは `r-rspm-description-file` の回復が期待値です(r3.6/r4.0 fixtureの失敗は別問題「CS-rstudio-grdmインストール時のGitHub APIレートリミット」によるflakyなもので、本PRのスコープ外です)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)