### PR TITLE
[GRDM-60339] ワイルドカード形式のRバージョン指定でビルドが失敗する問題の修正

### DIFF
--- a/repo2docker/buildpacks/_rstudio.py
+++ b/repo2docker/buildpacks/_rstudio.py
@@ -77,6 +77,11 @@ def load_rstudio_yaml(path):
         return YAML().load(f)
 
 
+def parse_r_version(r_version):
+    """Parse an R version pin; conda pins like "r-base=4.4.*" leave a trailing dot."""
+    return V(r_version.rstrip("."))
+
+
 def rstudio_server_installer(r_version, rstudio_config):
     """Return (url, sha256) of the RStudio Server .deb to install.
 
@@ -103,6 +108,6 @@ def rstudio_server_installer(r_version, rstudio_config):
                 f"does not exist: {url} returned {resp.status_code}"
             )
         return url, sha256
-    if r_version and V(r_version) < V(RSTUDIO_MIN_R_VERSION):
+    if r_version and parse_r_version(r_version) < V(RSTUDIO_MIN_R_VERSION):
         return LEGACY_RSTUDIO_URL, LEGACY_RSTUDIO_SHA256
     return fetch_latest_rstudio_server()

--- a/tests/unit/test_rstudio.py
+++ b/tests/unit/test_rstudio.py
@@ -50,7 +50,7 @@ def clear_fetch_cache():
     fetch_latest_rstudio_server.cache_clear()
 
 
-@pytest.mark.parametrize("r_version", ["3.3.3", "3.5.3"])
+@pytest.mark.parametrize("r_version", ["3.3.3", "3.5.3", "3.5."])
 def test_legacy_rstudio_for_old_r(r_version):
     assert rstudio_server_installer(r_version, None) == (
         LEGACY_RSTUDIO_URL,
@@ -58,7 +58,7 @@ def test_legacy_rstudio_for_old_r(r_version):
     )
 
 
-@pytest.mark.parametrize("r_version", ["", "3.6", "4.2.1"])
+@pytest.mark.parametrize("r_version", ["", "3.6", "4.2.1", "4.4."])
 def test_latest_rstudio(r_version):
     with patch("repo2docker.buildpacks._rstudio.requests.get") as mock_get:
         mock_get.return_value.json.return_value = DOWNLOADS_JSON


### PR DESCRIPTION
environment.yml で `r-base=4.4.*` のようにワイルドカード形式でRのバージョンを指定しているリポジトリのビルドが、2026.07.0 で失敗する問題を修正します。

# 原因

conda buildpack がバージョン指定から抽出する文字列に末尾のドットが残り(`r-base=4.4.*` → `"4.4."`)、#26 で導入した RStudio インストーラ選択の semver パースが失敗します。

```
File ".../buildpacks/_rstudio.py", line 106, in rstudio_server_installer
    if r_version and V(r_version) < V(RSTUDIO_MIN_R_VERSION):
ValueError: 4.4. is not valid SemVer string
```

2026.06.0 までは RStudio の URL がハードコードされており `V(r_version)` を通る経路がなかったため、顕在化していませんでした。

# 変更

+ `parse_r_version()` を導入し、末尾のドットを除去してからパースするように変更
+ 既存テストにワイルドカード残滓のケース(`"3.5."`, `"4.4."`)を追加

[RDM-e2e-test-nb](https://github.com/RCOSDP/RDM-e2e-test-nb/actions/runs/29081218233) の BinderHub アドオンテスト(repo2docker 2026.07.0 指定)で検出された問題です。